### PR TITLE
Initialize promptdiff CLI scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Promptdiff
+
+A CLI tool to track and compare LLM output quality over time. This project is a work in progress.
+
+## Usage
+
+```bash
+pip install -e .[cli]
+promptdiff init tests/sample
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "promptdiff"
+version = "0.1.0"
+description = "CLI and dashboard tool to track and compare LLM output quality"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+authors = [
+  {name = "Promptdiff", email = "team@example.com"}
+]
+
+[project.scripts]
+promptdiff = "promptdiff.cli:app"
+
+[project.optional-dependencies]
+cli = ["typer[all] >=0.9.0"]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/promptdiff/__init__.py
+++ b/src/promptdiff/__init__.py
@@ -1,0 +1,6 @@
+"""Promptdiff main package."""
+
+__all__ = ["cli"]
+
+from .cli import app
+

--- a/src/promptdiff/cli.py
+++ b/src/promptdiff/cli.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import typer
+
+app = typer.Typer(help="Promptdiff CLI")
+
+
+@app.command()
+def init(testset: Path = typer.Argument(Path("tests/sample"), help="Test set directory")) -> None:
+    """Scaffold a new testset directory with sample files."""
+    testset_path = Path(testset)
+    testset_path.mkdir(parents=True, exist_ok=True)
+
+    (testset_path / "expected.json").write_text(json.dumps({}, indent=2))
+    (testset_path / "meta.yaml").write_text("# optional metadata\n")
+    typer.echo(f"Initialized testset at {testset_path}")
+
+
+@app.command()
+def record(flow: str, testset: str) -> None:
+    """Run flow on a test set and save results (placeholder)."""
+    typer.echo(f"Recording results for flow {flow} on {testset}")
+
+
+@app.command()
+def compare(run_a: str, run_b: str) -> None:
+    """Compare two past runs (placeholder)."""
+    typer.echo(f"Comparing {run_a} to {run_b}")
+
+
+@app.command()
+def dashboard() -> None:
+    """Launch local dashboard (placeholder)."""
+    typer.echo("Launching dashboard...")
+
+
+if __name__ == "__main__":
+    app()
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from promptdiff.cli import app
+
+
+runner = CliRunner()
+
+
+def test_init(tmp_path: Path) -> None:
+    testdir = tmp_path / "myset"
+    result = runner.invoke(app, ["init", str(testdir)])
+    assert result.exit_code == 0
+    assert (testdir / "expected.json").exists()
+    assert (testdir / "meta.yaml").exists()
+


### PR DESCRIPTION
## Summary
- set up `pyproject.toml` with project metadata and Typer CLI entrypoint
- implement CLI with stub commands (`init`, `record`, `compare`, `dashboard`)
- add package initializer
- provide README with installation example
- create minimal unit test for `init` command

## Testing
- `pip install -e .[cli]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879243f73e8832b88e8c4340c8e2d8a