### PR TITLE
Refactor CLI commands into separate modules

### DIFF
--- a/src/promptdiff/cli.py
+++ b/src/promptdiff/cli.py
@@ -1,41 +1,43 @@
 from __future__ import annotations
 
-import json
-import os
 from pathlib import Path
 
 import typer
+
+from .commands import (
+    compare_runs,
+    init_testset,
+    launch_dashboard,
+    record_results,
+)
 
 app = typer.Typer(help="Promptdiff CLI")
 
 
 @app.command()
-def init(testset: Path = typer.Argument(Path("tests/sample"), help="Test set directory")) -> None:
+def init(
+    testset: Path = typer.Argument(Path("tests/sample"), help="Test set directory"),
+) -> None:
     """Scaffold a new testset directory with sample files."""
-    testset_path = Path(testset)
-    testset_path.mkdir(parents=True, exist_ok=True)
-
-    (testset_path / "expected.json").write_text(json.dumps({}, indent=2))
-    (testset_path / "meta.yaml").write_text("# optional metadata\n")
-    typer.echo(f"Initialized testset at {testset_path}")
+    init_testset(testset)
 
 
 @app.command()
 def record(flow: str, testset: str) -> None:
     """Run flow on a test set and save results (placeholder)."""
-    typer.echo(f"Recording results for flow {flow} on {testset}")
+    record_results(flow, testset)
 
 
 @app.command()
 def compare(run_a: str, run_b: str) -> None:
     """Compare two past runs (placeholder)."""
-    typer.echo(f"Comparing {run_a} to {run_b}")
+    compare_runs(run_a, run_b)
 
 
 @app.command()
 def dashboard() -> None:
     """Launch local dashboard (placeholder)."""
-    typer.echo("Launching dashboard...")
+    launch_dashboard()
 
 
 if __name__ == "__main__":

--- a/src/promptdiff/commands/__init__.py
+++ b/src/promptdiff/commands/__init__.py
@@ -1,0 +1,13 @@
+"""Command implementations for the promptdiff CLI."""
+
+from .init import init_testset
+from .record import record_results
+from .compare import compare_runs
+from .dashboard import launch_dashboard
+
+__all__ = [
+    "init_testset",
+    "record_results",
+    "compare_runs",
+    "launch_dashboard",
+]

--- a/src/promptdiff/commands/compare.py
+++ b/src/promptdiff/commands/compare.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import typer
+
+
+def compare_runs(run_a: str, run_b: str) -> None:
+    """Compare two past runs (placeholder)."""
+    typer.echo(f"Comparing {run_a} to {run_b}")

--- a/src/promptdiff/commands/dashboard.py
+++ b/src/promptdiff/commands/dashboard.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import typer
+
+
+def launch_dashboard() -> None:
+    """Launch local dashboard (placeholder)."""
+    typer.echo("Launching dashboard...")

--- a/src/promptdiff/commands/init.py
+++ b/src/promptdiff/commands/init.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+
+
+def init_testset(testset: Path) -> None:
+    """Scaffold a new testset directory with sample files."""
+    testset_path = Path(testset)
+    testset_path.mkdir(parents=True, exist_ok=True)
+
+    (testset_path / "expected.json").write_text(json.dumps({}, indent=2))
+    (testset_path / "meta.yaml").write_text("# optional metadata\n")
+    typer.echo(f"Initialized testset at {testset_path}")

--- a/src/promptdiff/commands/record.py
+++ b/src/promptdiff/commands/record.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import typer
+
+
+def record_results(flow: str, testset: str) -> None:
+    """Run flow on a test set and save results (placeholder)."""
+    typer.echo(f"Recording results for flow {flow} on {testset}")


### PR DESCRIPTION
## Summary
- create `commands` package to hold implementation for CLI actions
- move the logic for `init`, `record`, `compare`, and `dashboard` out of `cli.py`
- keep `cli.py` as a thin Typer wrapper

## Testing
- `pip install "typer[all]>=0.9.0"`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fff9e17d0832b8040b56d837df142